### PR TITLE
Fix Grammar Error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -328,7 +328,7 @@ fn main() {
             {
                 if !ignore_progress {
                     eprintln!(
-                        "{} crate `{}` don't have feature `{}`",
+                        "{} crate `{}` doesn't have feature `{}`",
                         Color::Yellow.bold().paint(
                             "Skipping".pad_to_width_with_alignment(12, pad::Alignment::Right)
                         ),


### PR DESCRIPTION
When trying to add a feature that doesn't exist, the current error message is `crate {crate_name} don't have {feature}`. This should read  `crate {crate_name} doesn't have {feature}`.
