### PR TITLE
nit: Fix pacman command line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ### Arch
 
-`pacman -Syu cargo-feature`
+`pacman -S cargo-feature`
 
 ### NixOS
 


### PR DESCRIPTION
`-S` only installs a package, while `-Syu` installs a package *and* performs a system upgrade.